### PR TITLE
 Fix code block formatting issue by replacing `<br>` tags with newline characters

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -150,6 +150,10 @@ function dohl () {
      * Enclose <pre></pre> blocks content in <code></code> blocks
      */
     for (const pre of preList) {
+        /* Replace all <br> tags with newline characters */
+        const codeBlock = pre.querySelector('code');
+        codeBlock.innerHTML = codeBlock.innerHTML.replace(/<br>/g, '\n');
+
         const firstChild = pre.firstChild;
         const code = document.createElement("code");
         let tabsize = "";

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -152,7 +152,9 @@ function dohl () {
     for (const pre of preList) {
         /* Replace all <br> tags with newline characters */
         const codeBlock = pre.querySelector('code');
-        codeBlock.innerHTML = codeBlock.innerHTML.replace(/<br[ /]*>/g, '\n');
+        if (codeBlock) {
+            codeBlock.innerHTML = codeBlock.innerHTML.replace(/<br[ /]*>/g, '\n');
+        }
 
         const firstChild = pre.firstChild;
         const code = document.createElement("code");

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -152,7 +152,7 @@ function dohl () {
     for (const pre of preList) {
         /* Replace all <br> tags with newline characters */
         const codeBlock = pre.querySelector('code');
-        codeBlock.innerHTML = codeBlock.innerHTML.replace(/<br>/g, '\n');
+        codeBlock.innerHTML = codeBlock.innerHTML.replace(/<br[ /]*>/g, '\n');
 
         const firstChild = pre.firstChild;
         const code = document.createElement("code");


### PR DESCRIPTION
This pull request (from [issue 18](https://github.com/Qeole/Enlight/issues/18)  fixes an issue with code block formatting where `<br>` tags were causing the entire block to be displayed on a single line. To resolve this issue, I have modified the content.js file to replace all `<br>` tags inside `<code></code>` tags with newline characters. This ensures that the code block is formatted correctly and each line is displayed on a separate line.

I have tested this fix on Firefox and verified that it resolves the formatting issue without causing any regressions. Please review this pull request and let me know if there are any further changes or tests needed before merging.

I used the same example from the [issue](https://github.com/Qeole/Enlight/issues/18#issue-1630740009)

**before fix:**
![image](https://user-images.githubusercontent.com/13495284/226213677-c3c03589-cb6c-4d5b-9577-554370100ada.png)

```html
<code class="language-markup">template &lt;typename T, typename F&gt;<br>std::vector&lt;T&gt; palter(std::vector&lt;T&gt; data, F&amp;&amp; f)<br>{<br>   ptransform(std::begin(data), std::end(data),<br>              std::forward&lt;F&gt;(f));<br>   return data;<br>}</code>
```

**after fix:**
![image](https://user-images.githubusercontent.com/13495284/226213248-411dce7d-9023-4492-b5c9-13a286147f5e.png)

```html
<code class="language-cpp hljs" style="padding: 0px; tab-size: 8;"><span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">typename</span> T, <span class="hljs-keyword">typename</span> F&gt;
<span class="hljs-function">std::vector&lt;T&gt; <span class="hljs-title">palter</span><span class="hljs-params">(std::vector&lt;T&gt; data, F&amp;&amp; f)</span>
</span>{
   <span class="hljs-built_in">ptransform</span>(std::<span class="hljs-built_in">begin</span>(data), std::<span class="hljs-built_in">end</span>(data),
              std::forward&lt;F&gt;(f));
   <span class="hljs-keyword">return</span> data;
}</code>
```